### PR TITLE
Day 20

### DIFF
--- a/day_20/README.md
+++ b/day_20/README.md
@@ -1,0 +1,125 @@
+### Day 20: Pulse Propagation
+
+With your help, the Elves manage to find the right parts and fix all of the machines. Now, they just need to send the command to boot up the machines and get the sand flowing again.
+
+The machines are far apart and wired together with long cables. The cables don't connect to the machines directly, but rather to communication modules attached to the machines that perform various initialization tasks and also act as communication relays.
+
+Modules communicate using pulses. Each pulse is either a high pulse or a low pulse. When a module sends a pulse, it sends that type of pulse to each module in its list of destination modules.
+
+There are several different types of modules:
+
+Flip-flop modules (prefix %) are either on or off; they are initially off. If a flip-flop module receives a high pulse, it is ignored and nothing happens. However, if a flip-flop module receives a low pulse, it flips between on and off. If it was off, it turns on and sends a high pulse. If it was on, it turns off and sends a low pulse.
+
+Conjunction modules (prefix &) remember the type of the most recent pulse received from each of their connected input modules; they initially default to remembering a low pulse for each input. When a pulse is received, the conjunction module first updates its memory for that input. Then, if it remembers high pulses for all inputs, it sends a low pulse; otherwise, it sends a high pulse.
+
+There is a single broadcast module (named broadcaster). When it receives a pulse, it sends the same pulse to all of its destination modules.
+
+Here at Desert Machine Headquarters, there is a module with a single button on it called, aptly, the button module. When you push the button, a single low pulse is sent directly to the broadcaster module.
+
+After pushing the button, you must wait until all pulses have been delivered and fully handled before pushing it again. Never push the button if modules are still processing pulses.
+
+Pulses are always processed in the order they are sent. So, if a pulse is sent to modules a, b, and c, and then module a processes its pulse and sends more pulses, the pulses sent to modules b and c would have to be handled first.
+
+The module configuration (your puzzle input) lists each module. The name of the module is preceded by a symbol identifying its type, if any. The name is then followed by an arrow and a list of its destination modules. For example:
+
+```
+broadcaster -> a, b, c
+%a -> b
+%b -> c
+%c -> inv
+&inv -> a
+```
+In this module configuration, the broadcaster has three destination modules named a, b, and c. Each of these modules is a flip-flop module (as indicated by the % prefix). a outputs to b which outputs to c which outputs to another module named inv. inv is a conjunction module (as indicated by the & prefix) which, because it has only one input, acts like an inverter (it sends the opposite of the pulse type it receives); it outputs to a.
+
+By pushing the button once, the following pulses are sent:
+
+```
+button -low-> broadcaster
+broadcaster -low-> a
+broadcaster -low-> b
+broadcaster -low-> c
+a -high-> b
+b -high-> c
+c -high-> inv
+inv -low-> a
+a -low-> b
+b -low-> c
+c -low-> inv
+inv -high-> a
+```
+After this sequence, the flip-flop modules all end up off, so pushing the button again repeats the same sequence.
+
+Here's a more interesting example:
+
+```
+broadcaster -> a
+%a -> inv, con
+&inv -> b
+%b -> con
+&con -> output
+```
+This module configuration includes the broadcaster, two flip-flops (named a and b), a single-input conjunction module (inv), a multi-input conjunction module (con), and an untyped module named output (for testing purposes). The multi-input conjunction module con watches the two flip-flop modules and, if they're both on, sends a low pulse to the output module.
+
+Here's what happens if you push the button once:    
+
+```
+button -low-> broadcaster
+broadcaster -low-> a
+a -high-> inv
+a -high-> con
+inv -low-> b
+con -high-> output
+b -high-> con
+con -low-> output
+```
+Both flip-flops turn on and a low pulse is sent to output! However, now that both flip-flops are on and con remembers a high pulse from each of its two inputs, pushing the button a second time does something different:
+
+```
+button -low-> broadcaster
+broadcaster -low-> a
+a -low-> inv
+a -low-> con
+inv -high-> b
+con -high-> output
+```
+Flip-flop a turns off! Now, con remembers a low pulse from module a, and so it sends only a high pulse to output.
+
+Push the button a third time:
+
+```
+button -low-> broadcaster
+broadcaster -low-> a
+a -high-> inv
+a -high-> con
+inv -low-> b
+con -low-> output
+b -low-> con
+con -high-> output
+```
+This time, flip-flop a turns on, then flip-flop b turns off. However, before b can turn off, the pulse sent to con is handled first, so it briefly remembers all high pulses for its inputs and sends a low pulse to output. After that, flip-flop b turns off, which causes con to update its state and send a high pulse to output.
+
+Finally, with a on and b off, push the button a fourth time:
+
+```
+button -low-> broadcaster
+broadcaster -low-> a
+a -low-> inv
+a -low-> con
+inv -high-> b
+con -high-> output
+```
+This completes the cycle: a turns off, causing con to remember only low pulses and restoring all modules to their original states.
+
+To get the cables warmed up, the Elves have pushed the button 1000 times. How many pulses got sent as a result (including the pulses sent by the button itself)?
+
+In the first example, the same thing happens every time the button is pushed: 8 low pulses and 4 high pulses are sent. So, after pushing the button 1000 times, 8000 low pulses and 4000 high pulses are sent. Multiplying these together gives 32000000.
+
+In the second example, after pushing the button 1000 times, 4250 low pulses and 2750 high pulses are sent. Multiplying these together gives 11687500.
+
+Consult your module configuration; determine the number of low pulses and high pulses that would be sent after pushing the button 1000 times, waiting for all pulses to be fully handled after each push of the button. What do you get if you multiply the total number of low pulses sent by the total number of high pulses sent?
+
+#### Part Two
+
+The final machine responsible for moving the sand down to Island Island has a module attached named rx. The machine turns on when a single low pulse is sent to rx.
+
+Reset all modules to their default states. Waiting for all pulses to be fully handled after each button press, what is the fewest number of button presses required to deliver a single low pulse to the module named rx?

--- a/day_20/input
+++ b/day_20/input
@@ -1,0 +1,58 @@
+%xf -> qr
+%qr -> bt, zt
+%xm -> gp, cq
+%zs -> ct
+&vg -> lg
+%dx -> bt, tz
+%tq -> jm
+%pr -> gp, pf
+&nb -> lg
+%tz -> bt
+%kj -> fk
+%hx -> rb
+%xh -> zs, rb
+&vc -> lg
+%tl -> bn
+%bb -> kf, rb
+%nn -> xf, bt
+%nk -> nn, bt
+%kp -> vk
+&bt -> tl, nk, pb, xf, vg
+%sr -> vs, ml
+%sh -> zk
+%jm -> ml, kp
+%kq -> tl, bt
+%vs -> tq, ml
+%sv -> dx, bt
+%gs -> gp
+%kf -> rb, ph
+%ct -> rt, rb
+%sj -> kj, rb
+%kh -> ml
+%nt -> gs, gp
+%bn -> sv, bt
+%lx -> ff, gp
+%rt -> hq
+%ph -> rb, hx
+&ls -> lg
+%nv -> xm
+%df -> nv
+%vk -> tk
+%cq -> gp, mq
+%hq -> bb
+&lg -> rx
+%zk -> ml, ps
+&ml -> kp, sr, tq, nb, tk, sh, vk
+%pf -> gp, nt
+%ff -> gp, df
+%zt -> pb, bt
+broadcaster -> sj, sr, tp, nk
+%mq -> pr
+&rb -> vc, zs, fk, hq, rt, sj, kj
+%pb -> kq
+%qz -> ml, kh
+%tp -> gp, lx
+%tk -> sh
+&gp -> df, ls, mq, tp, nv
+%fk -> xh
+%ps -> qz, ml

--- a/day_20/solution.go
+++ b/day_20/solution.go
@@ -1,0 +1,311 @@
+package day20
+
+import (
+	"container/list"
+	"fmt"
+	"github.com/pivovarit/aoc/util"
+	"math"
+	"slices"
+	"strings"
+)
+
+func run() {
+	input := util.ReadInput()
+
+	util.Timed("pulsePropagationPart1", func() int {
+		return pulsePropagationPart1(input)
+	})
+	util.Timed("pulsePropagationPart2", func() int {
+		return pulsePropagationPart2(input)
+	})
+}
+
+const (
+	noSignal SignalType = iota
+	low
+	high
+)
+
+const (
+	conjunction rune = '&'
+	flipFlop    rune = '%'
+	arrow            = "->"
+)
+
+const (
+	conjunctionModule ModuleType = iota
+	flipFlopModule
+)
+
+type Module interface {
+	emit(signalType SignalType) SignalType
+	receive(signalType SignalType, source string)
+	targets() []string
+	moduleType() ModuleType
+	name() string
+}
+
+type (
+	ModuleType     uint8
+	SignalType     uint8
+	FlipFlopModule struct {
+		id          string
+		destination []string
+		on          bool
+	}
+	ConjunctionModule struct {
+		id          string
+		destination []string
+		downstream  map[string]SignalType
+	}
+	QueueItem struct {
+		sender, node string
+		signal       SignalType
+	}
+)
+
+func (m *FlipFlopModule) moduleType() ModuleType {
+	return flipFlopModule
+}
+
+func (m *FlipFlopModule) receive(SignalType, string) {
+}
+
+func (m *FlipFlopModule) emit(signalType SignalType) SignalType {
+	switch signalType {
+	case low:
+		if !m.on {
+			m.on = !m.on
+			return high
+		} else {
+			m.on = !m.on
+			return low
+		}
+	case high:
+		return noSignal
+	default:
+		panic("illegal signal type")
+	}
+}
+
+func (m *FlipFlopModule) name() string {
+	return m.id
+}
+
+func (m *FlipFlopModule) targets() []string {
+	return m.destination
+}
+
+func (m *ConjunctionModule) name() string {
+	return m.id
+}
+
+func (m *ConjunctionModule) moduleType() ModuleType {
+	return conjunctionModule
+}
+
+func (m *ConjunctionModule) emit(SignalType) SignalType {
+	for _, signal := range m.downstream {
+		if signal == low {
+			return high
+		}
+	}
+	return low
+}
+
+func (m *FlipFlopModule) String() string {
+	return fmt.Sprintf("name: %s, type: %s, targets: %s, on: %v", m.id, "flip-flop", m.destination, m.on)
+}
+
+func (m *ConjunctionModule) receive(signalType SignalType, source string) {
+	m.downstream[source] = signalType
+}
+
+func (m *ConjunctionModule) targets() []string {
+	return m.destination
+}
+
+func (m *ConjunctionModule) String() string {
+	return fmt.Sprintf("name: %s, type: %s, targets: %s, downstream: %v", m.id, "conjunction", m.destination, m.downstream)
+}
+
+func pulsePropagationPart1(input []string) int {
+	broadcaster, modules := parse(input)
+	sumHigh := 0
+	sumLow := 0
+	for i := 0; i < 1000; i++ {
+		lowPulses, highPulses := propagateCounting(broadcaster, modules)
+		sumLow += lowPulses + 1
+		sumHigh += highPulses
+
+	}
+	return sumHigh * sumLow
+}
+
+func propagateUntilHigh(broadcaster []string, modules map[string]Module, nodes []string) map[string]int {
+	var cyclesToHigh = make(map[string]int)
+	for _, node := range nodes {
+		cyclesToHigh[node] = 0
+	}
+
+	for cycle := 1; cycle < math.MaxInt; cycle++ {
+		processingQueue := list.New()
+		for _, node := range broadcaster {
+			processingQueue.PushBack(QueueItem{
+				sender: "broadcaster",
+				node:   node,
+				signal: low,
+			})
+		}
+
+		for processingQueue.Len() > 0 {
+			item := processingQueue.Front()
+			body := item.Value.(QueueItem)
+			processingQueue.Remove(item)
+
+			if slices.Contains(nodes, body.sender) && body.signal == high {
+				if cyclesToHigh[body.sender] == 0 {
+					cyclesToHigh[body.sender] = cycle
+				}
+				var found = true
+				for _, v := range cyclesToHigh {
+					if v == 0 {
+						found = false
+					}
+				}
+
+				if found {
+					return cyclesToHigh
+				}
+			}
+
+			module, exists := modules[body.node]
+			if exists {
+				module.receive(body.signal, body.sender)
+				signal := module.emit(body.signal)
+				if signal != noSignal {
+					for _, target := range module.targets() {
+						processingQueue.PushBack(QueueItem{body.node, target, signal})
+					}
+				}
+			}
+		}
+	}
+	return cyclesToHigh
+}
+
+func propagateCounting(broadcaster []string, modules map[string]Module) (int, int) {
+	lowPulses := 0
+	highPulses := 0
+	processingQueue := list.New()
+	for _, node := range broadcaster {
+		processingQueue.PushBack(QueueItem{
+			sender: "broadcaster",
+			node:   node,
+			signal: low,
+		})
+	}
+
+	for processingQueue.Len() > 0 {
+		item := processingQueue.Front()
+		body := item.Value.(QueueItem)
+		processingQueue.Remove(item)
+
+		switch body.signal {
+		case low:
+			lowPulses++
+		case high:
+			highPulses++
+		}
+
+		module, exists := modules[body.node]
+		if exists {
+			module.receive(body.signal, body.sender)
+			signal := module.emit(body.signal)
+			if signal != noSignal {
+				for _, target := range module.targets() {
+					processingQueue.PushBack(QueueItem{body.node, target, signal})
+				}
+			}
+		}
+	}
+	return lowPulses, highPulses
+}
+
+func pulsePropagationPart2(input []string) int {
+	broadcaster, modules := parse(input)
+	rxDependency := findDependencies("rx", modules)[0]
+	dependencies := findDependencies(rxDependency, modules)
+	var cycles []int
+	for _, i := range propagateUntilHigh(broadcaster, modules, dependencies) {
+		cycles = append(cycles, i)
+	}
+	return lcm(cycles)
+}
+
+func findDependencies(node string, modules map[string]Module) (result []string) {
+	for _, module := range modules {
+		if slices.Contains(module.targets(), node) {
+			result = append(result, module.name())
+		}
+	}
+	return
+}
+
+func parse(input []string) ([]string, map[string]Module) {
+	var modules = make(map[string]Module)
+	var conjunctionModules []string
+	var broadcaster []string
+
+	for _, line := range input {
+		var targets []string
+		for _, target := range strings.Split(line[strings.Index(line, arrow)+len(arrow):], ",") {
+			targets = append(targets, strings.TrimSpace(target))
+		}
+
+		module := strings.TrimSpace(line[:strings.Index(line, arrow)])
+
+		if rune(module[0]) == flipFlop {
+			m := FlipFlopModule{module[1:], targets, false}
+			modules[module[1:]] = &m
+		} else if rune(module[0]) == conjunction {
+			m := ConjunctionModule{module[1:], targets, map[string]SignalType{}}
+			modules[module[1:]] = &m
+			conjunctionModules = append(conjunctionModules, m.name())
+		} else {
+			broadcaster = targets
+		}
+	}
+
+	for _, moduleName := range conjunctionModules {
+		cm := modules[moduleName]
+		var downstream = make(map[string]SignalType)
+		for _, dependency := range modules {
+			if slices.Contains(dependency.targets(), cm.name()) {
+				downstream[dependency.name()] = low
+			}
+		}
+		modules[moduleName] = &ConjunctionModule{
+			id:          moduleName,
+			destination: cm.targets(),
+			downstream:  downstream,
+		}
+	}
+
+	return broadcaster, modules
+}
+
+func lcm(numbers []int) int {
+	result := 1
+	for _, x := range numbers {
+		gcd := result
+		b := x
+		for b != 0 {
+			t := b
+			b = gcd % b
+			gcd = t
+		}
+		result = result / gcd * x
+	}
+	return result
+}

--- a/day_20/solution_test.go
+++ b/day_20/solution_test.go
@@ -1,0 +1,72 @@
+package day20
+
+import (
+	"github.com/pivovarit/aoc/util"
+	"testing"
+)
+
+var input = util.ReadInput()
+
+func Test_run(t *testing.T) {
+	run()
+}
+
+func BenchmarkPulsePropagationPart1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pulsePropagationPart1(input)
+	}
+}
+
+func BenchmarkPulsePropagationPart2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pulsePropagationPart2(input)
+	}
+}
+
+func Test_pulsePropagationPart1(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  int
+	}{
+		{name: "example", input: input, want: 929810733},
+		{name: "example 1", input: []string{
+			"broadcaster -> a, b, c",
+			"%a -> b",
+			"%b -> c",
+			"%c -> inv",
+			"&inv -> a",
+		}, want: 32000000},
+		{name: "example 2", input: []string{
+			"broadcaster -> a",
+			"%a -> inv, con",
+			"&inv -> b",
+			"%b -> con",
+			"&con -> output",
+		}, want: 11687500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pulsePropagationPart1(tt.input); got != tt.want {
+				t.Errorf("pulsePropagationPart1() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_pulsePropagationPart2(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  int
+	}{
+		{name: "example", input: input, want: 231657829136023},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pulsePropagationPart2(tt.input); got != tt.want {
+				t.Errorf("pulsePropagationPart2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Day 20: Pulse Propagation

With your help, the Elves manage to find the right parts and fix all of the machines. Now, they just need to send the command to boot up the machines and get the sand flowing again.

The machines are far apart and wired together with long cables. The cables don't connect to the machines directly, but rather to communication modules attached to the machines that perform various initialization tasks and also act as communication relays.

Modules communicate using pulses. Each pulse is either a high pulse or a low pulse. When a module sends a pulse, it sends that type of pulse to each module in its list of destination modules.

There are several different types of modules:

Flip-flop modules (prefix %) are either on or off; they are initially off. If a flip-flop module receives a high pulse, it is ignored and nothing happens. However, if a flip-flop module receives a low pulse, it flips between on and off. If it was off, it turns on and sends a high pulse. If it was on, it turns off and sends a low pulse.

Conjunction modules (prefix &) remember the type of the most recent pulse received from each of their connected input modules; they initially default to remembering a low pulse for each input. When a pulse is received, the conjunction module first updates its memory for that input. Then, if it remembers high pulses for all inputs, it sends a low pulse; otherwise, it sends a high pulse.

There is a single broadcast module (named broadcaster). When it receives a pulse, it sends the same pulse to all of its destination modules.

Here at Desert Machine Headquarters, there is a module with a single button on it called, aptly, the button module. When you push the button, a single low pulse is sent directly to the broadcaster module.

After pushing the button, you must wait until all pulses have been delivered and fully handled before pushing it again. Never push the button if modules are still processing pulses.

Pulses are always processed in the order they are sent. So, if a pulse is sent to modules a, b, and c, and then module a processes its pulse and sends more pulses, the pulses sent to modules b and c would have to be handled first.

The module configuration (your puzzle input) lists each module. The name of the module is preceded by a symbol identifying its type, if any. The name is then followed by an arrow and a list of its destination modules. For example:

```
broadcaster -> a, b, c
%a -> b
%b -> c
%c -> inv
&inv -> a
```
In this module configuration, the broadcaster has three destination modules named a, b, and c. Each of these modules is a flip-flop module (as indicated by the % prefix). a outputs to b which outputs to c which outputs to another module named inv. inv is a conjunction module (as indicated by the & prefix) which, because it has only one input, acts like an inverter (it sends the opposite of the pulse type it receives); it outputs to a.

By pushing the button once, the following pulses are sent:

```
button -low-> broadcaster
broadcaster -low-> a
broadcaster -low-> b
broadcaster -low-> c
a -high-> b
b -high-> c
c -high-> inv
inv -low-> a
a -low-> b
b -low-> c
c -low-> inv
inv -high-> a
```
After this sequence, the flip-flop modules all end up off, so pushing the button again repeats the same sequence.

Here's a more interesting example:

```
broadcaster -> a
%a -> inv, con
&inv -> b
%b -> con
&con -> output
```
This module configuration includes the broadcaster, two flip-flops (named a and b), a single-input conjunction module (inv), a multi-input conjunction module (con), and an untyped module named output (for testing purposes). The multi-input conjunction module con watches the two flip-flop modules and, if they're both on, sends a low pulse to the output module.

Here's what happens if you push the button once:    

```
button -low-> broadcaster
broadcaster -low-> a
a -high-> inv
a -high-> con
inv -low-> b
con -high-> output
b -high-> con
con -low-> output
```
Both flip-flops turn on and a low pulse is sent to output! However, now that both flip-flops are on and con remembers a high pulse from each of its two inputs, pushing the button a second time does something different:

```
button -low-> broadcaster
broadcaster -low-> a
a -low-> inv
a -low-> con
inv -high-> b
con -high-> output
```
Flip-flop a turns off! Now, con remembers a low pulse from module a, and so it sends only a high pulse to output.

Push the button a third time:

```
button -low-> broadcaster
broadcaster -low-> a
a -high-> inv
a -high-> con
inv -low-> b
con -low-> output
b -low-> con
con -high-> output
```
This time, flip-flop a turns on, then flip-flop b turns off. However, before b can turn off, the pulse sent to con is handled first, so it briefly remembers all high pulses for its inputs and sends a low pulse to output. After that, flip-flop b turns off, which causes con to update its state and send a high pulse to output.

Finally, with a on and b off, push the button a fourth time:

```
button -low-> broadcaster
broadcaster -low-> a
a -low-> inv
a -low-> con
inv -high-> b
con -high-> output
```
This completes the cycle: a turns off, causing con to remember only low pulses and restoring all modules to their original states.

To get the cables warmed up, the Elves have pushed the button 1000 times. How many pulses got sent as a result (including the pulses sent by the button itself)?

In the first example, the same thing happens every time the button is pushed: 8 low pulses and 4 high pulses are sent. So, after pushing the button 1000 times, 8000 low pulses and 4000 high pulses are sent. Multiplying these together gives 32000000.

In the second example, after pushing the button 1000 times, 4250 low pulses and 2750 high pulses are sent. Multiplying these together gives 11687500.

Consult your module configuration; determine the number of low pulses and high pulses that would be sent after pushing the button 1000 times, waiting for all pulses to be fully handled after each push of the button. What do you get if you multiply the total number of low pulses sent by the total number of high pulses sent?

#### Part Two

The final machine responsible for moving the sand down to Island Island has a module attached named rx. The machine turns on when a single low pulse is sent to rx.

Reset all modules to their default states. Waiting for all pulses to be fully handled after each button press, what is the fewest number of button presses required to deliver a single low pulse to the module named rx?
